### PR TITLE
Add env-configurable base path for Netlify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@
 - Fixed functions directory path so Netlify deploy detects Python functions.
 - Added base path stripping and included files to ensure Flask routes work on Netlify.
 - Made Flask server port configurable via `PORT` env variable and updated Dockerfile.
+- Read serverless function base path from `API_GATEWAY_BASE_PATH` environment
+  variable and documented the setting in Netlify configuration.

--- a/ISSUES_LOG.md
+++ b/ISSUES_LOG.md
@@ -6,5 +6,5 @@
 - [x] Netlify deploy failed to parse configuration; replaced `python_runtime` with `python_version`.
 - [x] Netlify deploy still failed due to `python_version`; removed the property entirely.
 - [x] Netlify deploy preview served 404s due to functions not detected; added explicit directory setting.
-- [ ] Deployed site still returns 404; added base path stripping and included files for templates.
+- [ ] Deployed site still returns 404; added base path stripping and included files for templates. Parameterized the base path via `API_GATEWAY_BASE_PATH` to allow configuration. Pending verification after next deploy.
 - [ ] Docker container may not honor `PORT` variable due to exec-form CMD.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ By default, the web service is exposed on port `8282`.
 1. Install the Netlify CLI and log in with `netlify login`.
 2. Run `netlify deploy --prod` to build and deploy.
 3. Configure the `OLLAMA_*` variables in the Netlify dashboard.
+4. Ensure `API_GATEWAY_BASE_PATH` is set in the Netlify environment. This
+   variable defines the base path used by the serverless function and defaults to
+   `/.netlify/functions/flask_app`.
 
 ## Troubleshooting
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,3 +13,4 @@
 - [ ] Verify 404 issue is resolved with base path stripping.
 - [x] Allow Flask port to be set via `PORT` environment variable.
 - [ ] Verify Gunicorn command expands `$PORT` properly in Dockerfile.
+- [x] Parameterize Netlify base path via `API_GATEWAY_BASE_PATH` environment variable.

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,7 @@
   included_files = ["templates/**/*", "static/**/*", "app.py"]
 
   [functions.environment]
+    # Base path for the Flask function used for stripping in flask_app.py
     API_GATEWAY_BASE_PATH = "/.netlify/functions/flask_app"
 
 [[redirects]]

--- a/netlify/functions/flask_app.py
+++ b/netlify/functions/flask_app.py
@@ -1,8 +1,10 @@
 from app import app
 from serverless_wsgi import handle_request
+import os
 
 # Strip the Netlify functions base path so Flask routes work correctly
-BASE_PATH = "/.netlify/functions/flask_app"
+# Read from API_GATEWAY_BASE_PATH env variable with a default
+BASE_PATH = os.getenv("API_GATEWAY_BASE_PATH", "/.netlify/functions/flask_app")
 
 def handler(event, context):
     # Remove the function's base path prefix so Flask sees the correct route


### PR DESCRIPTION
## Summary
- make the Netlify handler read `API_GATEWAY_BASE_PATH`
- document the variable in `netlify.toml` and README
- record the change in `CHANGELOG.md`, `ISSUES_LOG.md`, and `TODO.md`

## Testing
- `pip install -r requirements.txt`
- `python3 test.py` *(fails: upstream connect error or disconnect/reset before headers. reset reason: connection timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6851cc9f53e48323a9a06a042dc3dbe6