### PR TITLE
Fix python 3.9 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,5 @@
 - Made Flask server port configurable via `PORT` env variable and updated Dockerfile.
 - Read serverless function base path from `API_GATEWAY_BASE_PATH` environment
   variable and documented the setting in Netlify configuration.
+- Replaced Python 3.10 union type hints with `typing.Optional` for
+  compatibility with Netlify's Python runtime.

--- a/ISSUES_LOG.md
+++ b/ISSUES_LOG.md
@@ -8,4 +8,6 @@
 - [x] Netlify deploy still failed due to `python_version`; removed the property entirely.
 - [x] Netlify deploy preview served 404s due to functions not detected; added explicit directory setting.
 - [ ] Deployed site still returns 404; added base path stripping and included files for templates. Parameterized the base path via `API_GATEWAY_BASE_PATH` to allow configuration. Pending verification after next deploy.
+- [ ] Netlify Python runtime may be <3.10 causing syntax errors from union type
+      hints. Updated code to use `typing.Optional` for compatibility.
 - [ ] Docker container may not honor `PORT` variable due to exec-form CMD.

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,8 @@
 - [x] Validate Netlify deploy after removing python version setting.
 - [x] Confirm Netlify functions deploy correctly with new directory setting.
 - [ ] Verify 404 issue is resolved with base path stripping.
+- [ ] Test Netlify deploy after replacing union types with Optional for Python
+      3.9 compatibility.
 - [x] Allow Flask port to be set via `PORT` environment variable.
 - [ ] Verify Gunicorn command expands `$PORT` properly in Dockerfile.
 - [x] Parameterize Netlify base path via `API_GATEWAY_BASE_PATH` environment variable.

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ It includes:
 # nourrir_flask/app.py
 
 from flask import Flask, render_template, request, jsonify, send_from_directory
+from typing import Optional
 import os
 import requests
 import logging
@@ -56,7 +57,7 @@ SYSTEM_PROMPT = (
     "Sois amicale, inclusive, brève et adaptée à tous publics."
 )
 
-def query_ollama(messages: list, model: str = OLLAMA_MODEL, chat_url: str = OLLAMA_CHAT_URL, timeout: int = 60) -> str | None:
+def query_ollama(messages: list, model: str = OLLAMA_MODEL, chat_url: str = OLLAMA_CHAT_URL, timeout: int = 60) -> Optional[str]:
     """
     Sends messages to the Ollama chat API and returns the assistant's content.
 
@@ -120,7 +121,7 @@ def get_response_with_fallback(messages: list,
                                chat_url: str = OLLAMA_CHAT_URL,
                                models_url: str = OLLAMA_MODELS_URL,
                                initial_model: str = OLLAMA_MODEL,
-                               timeout: int = 60) -> str | None:
+                               timeout: int = 60) -> Optional[str]:
     """
     Attempt to get a response using the initial model, then fallback through available models if needed.
     """


### PR DESCRIPTION
## Summary
- replace Python 3.10 union type hints with `typing.Optional`
- document runtime compatibility change in changelog
- log issue about Python runtime in Issues log
- update TODO with deployment verification task

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d062a7f88323a90711cf2a11ddba