### PR TITLE
Add stage buttons to performance index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@
 - Fixed integration policy page by serving it at `/politique/` and redirecting the legacy path.
 - Added direct section links at the bottom of the performance index page and ensured dropdowns toggle via JavaScript.
 - Expanded route tests to cover all pages and updated politique path tests.
+- Added circular stage buttons on the performance index page with links to each phase and new route tests.

--- a/ISSUES_LOG.md
+++ b/ISSUES_LOG.md
@@ -17,6 +17,7 @@
 - [x] Netlify served raw Jinja templates due to missing build step; replaced config with Frozen-Flask to generate static HTML.
 - [x] Redirect did not forward the requested path to the Flask function; added `:splat` to the Netlify redirect.
 - [x] Netlify deploy uploaded 0 files because no publish directory was defined. Set `publish = "templates"` in `netlify.toml` to ensure pages are uploaded.
+- [x] Performance index lacked quick navigation buttons; added circular stage buttons and tests.
 - [ ] Netlify Python runtime may be <3.10 causing syntax errors from union type
       hints. Updated code to use `typing.Optional` for compatibility.
 - [ ] Docker container may not honor `PORT` variable due to exec-form CMD.

--- a/TODO.md
+++ b/TODO.md
@@ -27,3 +27,5 @@
  - [x] Add GitHub Actions workflow to test build.
 - [x] Expand unit tests for API endpoints and performance pages.
 - [x] Ensure Frozen-Flask outputs `.html` files for performance policy subpages.
+- [x] Add circular stage buttons linking to each phase.
+- [ ] Replace placeholder icons in stage buttons with branded graphics.

--- a/templates/base.html
+++ b/templates/base.html
@@ -202,6 +202,41 @@
             border-radius: 8px; /* Match container's border-radius */
         }
 
+        /* Circular stage buttons on performance index */
+        .stage-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 1.5em;
+            margin: 2em 0;
+        }
+        .stage-button {
+            width: 90px;
+            height: 90px;
+            border-radius: 50%;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            font-size: 15px;
+            font-weight: 500;
+            text-decoration: none;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .stage-button:hover {
+            transform: scale(1.05);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+        }
+        .stage-button .icon {
+            font-size: 24px;
+            margin-bottom: 4px;
+        }
+        .stage-button.semis { background: #4A4A4A; color: #00A8A0; }
+        .stage-button.croissance { background: #1F3A93; color: #00CCFF; }
+        .stage-button.recolte { background: #00A8A0; color: #FFFFFF; }
+        .stage-button.renouvellement { background: #2E2E2E; color: #66FF66; }
+
         /* Chatbot Thinking Indicator Styles */
         .thinking-indicator-dot span { /* Individual dot style */
             display: inline-block;

--- a/templates/performance_policy/index.html
+++ b/templates/performance_policy/index.html
@@ -22,6 +22,25 @@
     </ul>
 </details>
 
+<div class="stage-buttons">
+    <a href="{{ url_for('performance_section', section='01_phase1_semis') }}" class="stage-button semis" aria-label="Phase 1 – Semis">
+        <span class="icon">🌱</span>
+        <span class="label">Semis</span>
+    </a>
+    <a href="{{ url_for('performance_section', section='02_phase2_croissance') }}" class="stage-button croissance" aria-label="Phase 2 – Croissance">
+        <span class="icon">📈</span>
+        <span class="label">Croissance</span>
+    </a>
+    <a href="{{ url_for('performance_section', section='03_phase3_recolte') }}" class="stage-button recolte" aria-label="Phase 3 – Récolte">
+        <span class="icon">🏆</span>
+        <span class="label">Récolte</span>
+    </a>
+    <a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}" class="stage-button renouvellement" aria-label="Phase 4 – Renouvellement">
+        <span class="icon">🔄</span>
+        <span class="label">Renouvellement</span>
+    </a>
+</div>
+
 <h2>Objectif</h2>
 <p>Le présent document vise à encadrer le processus de gestion de la performance au sein de NourrIR. Il a pour but d’offrir un cadre structurant, cohérent et vivant qui soutient l’alignement stratégique, la croissance individuelle et collective, ainsi que la reconnaissance des contributions de chacun·e. Inspiré par la mission de NourrIR, ce processus met de l’avant une vision de la performance comme levier de développement durable, de dialogue continu et d’engagement.</p>
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import pytest
+from flask import url_for
 
 # Ensure the application module is importable when running tests, even if the
 # project root isn't automatically added to PYTHONPATH. This avoids failures
@@ -33,6 +34,14 @@ def test_contact(client):
 def test_performance(client):
     resp = client.get('/performance')
     assert resp.status_code == 200
+
+def test_performance_stage_buttons(client):
+    resp = client.get('/performance')
+    html = resp.data.decode('utf-8')
+    assert 'class="stage-button semis"' in html
+    assert url_for('performance_section', section='01_phase1_semis') in html
+    assert 'class="stage-button croissance"' in html
+    assert url_for('performance_section', section='04_phase4_renouvellement') in html
 
 def test_coulisses(client):
     resp = client.get('/coulisses')


### PR DESCRIPTION
## Summary
- implement circular stage buttons for performance phases
- style the stage buttons in base template
- update performance index page with new button links
- extend tests to check for stage buttons
- document change in changelog, TODO, and issues log

## Testing
- `pip install -q -r requirements.txt`
- `python freeze.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d7cbdb6883239b0a237686543ab9