### PR TITLE
Add tests for Ollama helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@
 - Added direct section links at the bottom of the performance index page and ensured dropdowns toggle via JavaScript.
 - Expanded route tests to cover all pages and updated politique path tests.
 - Added circular stage buttons on the performance index page with links to each phase and new route tests.
+- Added unit tests for Ollama query logic and fallback handling.

--- a/ISSUES_LOG.md
+++ b/ISSUES_LOG.md
@@ -21,3 +21,4 @@
 - [ ] Netlify Python runtime may be <3.10 causing syntax errors from union type
       hints. Updated code to use `typing.Optional` for compatibility.
 - [ ] Docker container may not honor `PORT` variable due to exec-form CMD.
+- Added tests for Ollama query and fallback functions to ensure reliability.

--- a/TODO.md
+++ b/TODO.md
@@ -29,3 +29,4 @@
 - [x] Ensure Frozen-Flask outputs `.html` files for performance policy subpages.
 - [x] Add circular stage buttons linking to each phase.
 - [ ] Replace placeholder icons in stage buttons with branded graphics.
+- [x] Add unit tests for Ollama query and fallback functions.

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from unittest import mock
+import pytest
+
+# Ensure local app module is importable
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from app import query_ollama, get_response_with_fallback
+
+
+def test_query_ollama_openai_structure():
+    messages = [{"role": "user", "content": "Hello"}]
+    response_data = {
+        "choices": [
+            {"message": {"content": "Hi there"}}
+        ]
+    }
+    with mock.patch("app.requests.post") as mock_post:
+        mock_resp = mock.Mock(status_code=200)
+        mock_resp.json.return_value = response_data
+        mock_post.return_value = mock_resp
+        result = query_ollama(messages)
+    assert result == "Hi there"
+
+
+def test_get_response_with_fallback_uses_secondary_model():
+    messages = [{"role": "user", "content": "Hi"}]
+    # First call to query_ollama will raise, second will succeed
+    with mock.patch("app.query_ollama", side_effect=[Exception("boom"), "ok"]):
+        with mock.patch("app.requests.get") as mock_get:
+            mock_get.return_value = mock.Mock(status_code=200, json=lambda: {
+                "data": [{"id": "primary"}, {"id": "secondary"}]
+            })
+            result = get_response_with_fallback(messages, initial_model="primary")
+    assert result == "ok"


### PR DESCRIPTION
## Summary
- test helper functions `query_ollama` and `get_response_with_fallback`
- log additions in CHANGELOG, TODO, and ISSUES_LOG

## Testing
- `python freeze.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852da04172883238d450636f0b56f08