### PR TITLE
Fix duplicate Docker instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@
 - Expanded route tests to cover all pages and updated politique path tests.
 - Added circular stage buttons on the performance index page with links to each phase and new route tests.
 - Added unit tests for Ollama query logic and fallback handling.
+- Fixed duplicate Docker build/run commands in README.

--- a/ISSUES_LOG.md
+++ b/ISSUES_LOG.md
@@ -22,3 +22,4 @@
       hints. Updated code to use `typing.Optional` for compatibility.
 - [ ] Docker container may not honor `PORT` variable due to exec-form CMD.
 - Added tests for Ollama query and fallback functions to ensure reliability.
+- [x] Duplicate Docker commands in README created confusion; removed extra build/run lines.

--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ Open your browser at [http://localhost:8080](http://localhost:8080).
 
 docker build -t nourrir-flask .
 docker run -d -p 8282:8080 \
-docker build -t nourrir-flask .
-docker run -d -p 8282:8080 \
   -e OLLAMA_CHAT_URL=https://ollama.artemis-ai.ca/v1/chat/completions \
   -e OLLAMA_MODELS_URL=https://ollama.artemis-ai.ca/v1/models \
   -e OLLAMA_MODEL=mistral:latest \

--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,4 @@ This branch implements the UI/UX revamp. See `REVAMP_ROADMAP.md` for full detail
 - [ ] TODO_tooltips.md - Tippy.js Tooltip Tasks
 
 Follow the tasks in the respective files to track progress. Once completed, mark the tasks in the corresponding file.
+- [x] Remove duplicate Docker commands in `README.md`.


### PR DESCRIPTION
## Summary
- remove duplicate `docker build` and `docker run` lines from README
- log the README cleanup in CHANGELOG and ISSUES_LOG
- mark the task done in TODO

## Testing
- `pip install -q -r requirements.txt`
- `python freeze.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e5f448f48323a0149347c845cb2e