### PR TITLE
Add Tippy glossary tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@
 - Fixed duplicate Docker build/run commands in README.
 - Implemented basic internationalization with i18next, French/English locale files, and a navbar language switcher.
 - Reworked layout using Tailwind sections and DaisyUI cards; removed redundant CSS and improved image alt text.
+- Integrated Tippy.js tooltips for glossary terms (dopamine, probiotiques, freemium, NurrIA) with theme-aware initialization and i18n support. Added tooltip translations in locale files.

--- a/ISSUES_LOG.md
+++ b/ISSUES_LOG.md
@@ -27,3 +27,4 @@
 - [ ] Ensure new theme toggle functions across browsers and persists across sessions.
 - [ ] Expand translations to remaining pages and content.
 - [x] Old page-specific CSS made maintenance difficult; migrated to Tailwind utility classes and DaisyUI components.
+- [ ] Verify mobile behavior of new tooltips.

--- a/TODO_tooltips.md
+++ b/TODO_tooltips.md
@@ -1,21 +1,21 @@
 # Tippy.js Tooltip Tasks
 
- - [ ] **Identify Tooltip Terms**: List jargon or concepts (e.g., "dopamine", "probiotiques", "freemium", "NuRiH Ami") and draft concise definitions.
+ - [x] **Identify Tooltip Terms**: List jargon or concepts (e.g., "dopamine", "probiotiques", "freemium", "NuRiH Ami") and draft concise definitions.
 
- - [ ] **Add `data-tippy-content`**: Wrap terms in spans:
+ - [x] **Add `data-tippy-content`**: Wrap terms in spans:
    ```html
    <span data-tippy-content="Definition of the term">term</span>
    ```
    Add `cursor-help` style for hover indication.
 
- - [ ] **Include Tippy.js Assets**: In `base.html` `<head>`:
+ - [x] **Include Tippy.js Assets**: In `base.html` `<head>`:
    ```html
    <link rel="stylesheet" href="https://unpkg.com/tippy.js@6/dist/tippy.css" />
    <script src="https://unpkg.com/@popperjs/core@2"></script>
    <script src="https://unpkg.com/tippy.js@6"></script>
    ```
 
- - [ ] **Initialize Tippy**: After DOM load:
+ - [x] **Initialize Tippy**: After DOM load:
    ```js
    document.addEventListener('DOMContentLoaded', () => {
      tippy('[data-tippy-content]', {
@@ -32,7 +32,7 @@
 
  - [ ] **Edge Cases**: Ensure tooltips do not overlap or disrupt layout on both desktop and mobile.
 
- - [ ] **i18n Integration (Optional)**: For multilingual tooltips, use `data-i18n-tooltip="key"` and update tooltip content on language switch.
+ - [x] **i18n Integration (Optional)**: For multilingual tooltips, use `data-i18n-tooltip="key"` and update tooltip content on language switch.
 
  - [ ] **No JS Fallback**: Accept that tooltips will not display without JS; consider an underline CSS hint if desired.
 

--- a/static/assets/locales/en/translation.json
+++ b/static/assets/locales/en/translation.json
@@ -48,5 +48,11 @@
     "workflow": "n8n Workflow of the HR Chatbot",
     "learning": "A Continuous Learning Project",
     "team": "Meet the Team"
+  },
+  "tooltips": {
+    "dopamine": "Neurotransmitter linked to pleasure and motivation.",
+    "probiotiques": "Beneficial microorganisms for gut balance.",
+    "freemium": "Business model with free base access and paid extras.",
+    "nurria": "NourrIR's virtual assistant."
   }
 }

--- a/static/assets/locales/fr/translation.json
+++ b/static/assets/locales/fr/translation.json
@@ -48,5 +48,11 @@
     "workflow": "Workflow n8n du Chatbot RH",
     "learning": "Un Projet d'Apprentissage Continu",
     "team": "Voici l'Équipe"
+  },
+  "tooltips": {
+    "dopamine": "Neurotransmetteur lié au plaisir et à la motivation.",
+    "probiotiques": "Micro-organismes bénéfiques pour la flore intestinale.",
+    "freemium": "Modèle gratuit avec options payantes.",
+    "nurria": "Assistante IA de NourrIR."
   }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,9 @@
     <link rel="icon" href="{{ url_for('serve_assets', filename='NEW_Images/logo_NO_BACKGROUND.png') }}">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@3.11.0/dist/full.css" />
+    <link rel="stylesheet" href="https://unpkg.com/tippy.js@6/dist/tippy.css" />
+    <script src="https://unpkg.com/@popperjs/core@2"></script>
+    <script src="https://unpkg.com/tippy.js@6"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <style>
         :root {
@@ -92,6 +95,7 @@
             cursor: pointer; /* Indicate interactivity */
             transition: opacity 0.15s, box-shadow 0.15s; /* Faster transition */
         }
+        .cursor-help { cursor: help; }
         button:hover, input[type="submit"]:hover, input[type="button"]:hover,
         button:focus, input[type="submit"]:focus, input[type="button"]:focus {
             opacity: 0.88; /* Adjusted opacity */
@@ -290,7 +294,7 @@
 <body>
     <header>
         <img src="{{ url_for('serve_assets', filename='NEW_Images/logo_NO_BACKGROUND.png') }}" alt="Logo NourrIR" class="logo">
-        <div class="slogan" data-i18n="header.slogan">On croque la dopamine.</div>
+        <div class="slogan" data-i18n="header.slogan">On croque la <span class="cursor-help" data-tippy-content="Neurotransmetteur lié au plaisir et à la motivation." data-i18n-tooltip="tooltips.dopamine">dopamine</span>.</div>
     </header>
     <nav x-data="{open:false}" class="navbar bg-base-100 sticky top-[158px] z-50 shadow-md" @keydown.escape.window="open=false">
         <div class="flex-1">
@@ -413,7 +417,7 @@
         <button id="nuria-close-btn" title="Fermer">✕</button> <!-- Updated ID -->
       </div>
       <div id="nuria-chat-log"> <!-- Updated ID -->
-        <div class="nuria-msg-bot">Bonjour ! Je suis <b>NurrIA</b>, votre guide bienveillante. Comment puis-je vous aider aujourd'hui ?</div> <!-- Updated Name and class -->
+        <div class="nuria-msg-bot">Bonjour ! Je suis <b><span class="cursor-help" data-tippy-content="Assistante IA de NourrIR" data-i18n-tooltip="tooltips.nurria">NurrIA</span></b>, votre guide bienveillante. Comment puis-je vous aider aujourd'hui ?</div> <!-- Updated Name and class -->
       </div>
       <form id="nuria-chat-form" autocomplete="off"> <!-- Updated ID -->
         <input id="nuria-chat-input" type="text" placeholder="Écrivez votre message..." required autocomplete="off" /> <!-- Updated ID and placeholder -->
@@ -609,17 +613,30 @@
             const lang = localStorage.getItem('lang') || 'fr';
             i18next.init({lng: lang, resources}, updateContent);
         });
-
         function updateContent() {
             document.querySelectorAll('[data-i18n]').forEach(el => {
                 el.innerHTML = i18next.t(el.dataset.i18n);
             });
+            document.querySelectorAll('[data-i18n-tooltip]').forEach(el => {
+                const content = i18next.t(el.dataset.i18nTooltip);
+                if (el._tippy) {
+                    el._tippy.setContent(content);
+                } else {
+                    el.setAttribute('data-tippy-content', content);
+                }
+            });
         }
-
         function switchLang(lng) {
             i18next.changeLanguage(lng, updateContent);
             localStorage.setItem('lang', lng);
         }
+    </script>
+    <script>
+        document.addEventListener("DOMContentLoaded", () => {
+            tippy("[data-tippy-content]", {
+                theme: (localStorage.getItem("theme") === "dark") ? "dark" : "light"
+            });
+        });
     </script>
     <script>
         // Ensure <details> dropdowns toggle reliably across browsers

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,14 +95,14 @@
         <li>Activités créatives guidées (dessin, écriture, cuisine intuitive, collage numérique)</li>
         <li>Capsules de vulgarisation scientifique sur la nutrition et la santé mentale</li>
         <li>Journal de bord interactif et coach virtuel empathique</li>
-        <li>Modèle freemium (accès de base gratuit + modules premium)</li>
+        <li>Modèle <span class="cursor-help" data-tippy-content="Modèle gratuit avec options payantes." data-i18n-tooltip="tooltips.freemium">freemium</span> (accès de base gratuit + modules premium)</li>
     </ul>
     <h2 class="text-xl font-bold mt-8 mb-2" data-i18n="index.science_title">Fondements scientifiques</h2>
     <ul>
         <li>Nutrition personnalisée et santé mentale (Jacka et al., 2023)</li>
         <li>Intelligence artificielle en diététique (CareyYaYa, 2024)</li>
         <li>Créativité et régulation émotionnelle (WellPower, 2023)</li>
-        <li>Impact des probiotiques sur l'humeur (Health.com, 2024)</li>
+        <li>Impact des <span class="cursor-help" data-tippy-content="Micro-organismes bénéfiques pour la flore intestinale." data-i18n-tooltip="tooltips.probiotiques">probiotiques</span> sur l'humeur (Health.com, 2024)</li>
     </ul>
     <h2 class="text-xl font-bold mt-8 mb-2" data-i18n="index.potential_title">Potentiel</h2>
     <p>


### PR DESCRIPTION
## Summary
- integrate Tippy.js and Popper.js in base template
- add tooltip styles and theme aware initialization
- provide French/English tooltip text for dopamine, probiotiques, freemium and NurrIA
- mark TODO_tooltips tasks complete

## Testing
- `pytest -q`
- `python freeze.py`

------
https://chatgpt.com/codex/tasks/task_e_6852f6115c748323acceafb5290ef653